### PR TITLE
Update runtime to 43

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.github.bcedu.vgrive.json
+++ b/com.github.bcedu.vgrive.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.github.bcedu.vgrive",
     "runtime": "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "44",
     "base" : "io.elementary.BaseApp",
-    "base-version" : "juno-21.08",
+    "base-version" : "juno-22.08",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.bcedu.vgrive",
     "finish-args": [
@@ -15,6 +15,7 @@
         "--filesystem=home"
     ],
     "modules": [
+        "shared-modules/libsoup/libsoup-2.4.json",
         {
             "name": "VGrive",
             "buildsystem": "meson",


### PR DESCRIPTION
Closes https://github.com/flathub/com.github.bcedu.vgrive/issues/9

Cannot bump to 44 as there is no libsoup-2.4